### PR TITLE
SITL defaults: disable NET serial ports

### DIFF
--- a/sitl/params/ottano-headless.parm
+++ b/sitl/params/ottano-headless.parm
@@ -34,6 +34,7 @@ INS_ACCSCAL_Y,1.001
 INS_ACCSCAL_Z,1.001
 INS_GYR_CAL,0 # taken from quadplane autotest parameters, just in case
 LOG_REPLAY,0 # causes random crashes on the Cygwin SITL
+@delete NET_P* # don't create network serial ports by default in SITL
 @delete PTCH_RATE_*
 PTCH_RATE_FF,1.407055
 PTCH_RATE_I,0.2125

--- a/sitl/params/ottano-realflight.parm
+++ b/sitl/params/ottano-realflight.parm
@@ -28,6 +28,7 @@ GPS_TYPE,1
 GPS_TYPE2,1
 @delete INS_*
 LOG_REPLAY,0 # causes random crashes on the Cygwin SITL
+@delete NET_P* # don't create network serial ports by default in SITL
 RNGFND1_PIN,0
 RNGFND1_SCALING,40
 RNGFND1_TYPE,1

--- a/sitl/params/volanti-headless.parm
+++ b/sitl/params/volanti-headless.parm
@@ -31,6 +31,7 @@ INS_ACCSCAL_Z,1.001
 INS_GYR_CAL,0 # taken from quadplane autotest parameters, just in case
 LOG_REPLAY,0 # causes random crashes on the Cygwin SITL
 NAVL1_PERIOD,14
+@delete NET_P* # don't create network serial ports by default in SITL
 @delete PTCH_RATE_*
 PTCH_RATE_FF,1.407055
 PTCH_RATE_I,0.2125

--- a/sitl/params/volanti-realflight.parm
+++ b/sitl/params/volanti-realflight.parm
@@ -20,6 +20,7 @@ GPS_TYPE,1
 GPS_TYPE2,1
 @delete INS_*
 LOG_REPLAY,0 # causes random crashes on the Cygwin SITL
+@delete NET_P* # don't create network serial ports by default in SITL
 RNGFND1_PIN,0
 RNGFND1_SCALING,40
 RNGFND1_TYPE,1


### PR DESCRIPTION
Any SITL, launched by any computer that is connected to the trailer’s Wi-Fi, will automatically start streaming MAVLink to GCS1’s Silvus connection. This will cause conflicts if someone happens to do this while the real aircraft is also trying to communicate on that port.

This is because I copy over the real aircraft’s parameters as a base for the SITL, then override them as needed. One thing I hadn’t considered was the fact that we are pulling the NET_P* parameters, which means the SITL, like the real bird, starts trying to UDP stream to 192.168.0.5:14550.