### PR TITLE
build(deps): bump the github-actions group with 2 updates

### DIFF
--- a/.github/workflows/external-build.yml
+++ b/.github/workflows/external-build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Create app token for integration repo
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
@@ -21,7 +21,7 @@ jobs:
           repositories: cxpilot
 
       - name: Dispatch build workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app.outputs.token }}
           script: |

--- a/.github/workflows/external-build.yml
+++ b/.github/workflows/external-build.yml
@@ -8,14 +8,14 @@ permissions:
 
 jobs:
   send:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Create app token for integration repo
         uses: actions/create-github-app-token@v3
         id: app
         with:
-          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          client-id: ${{ secrets.CI_BOT_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: cxpilot


### PR DESCRIPTION
This PR does three things:

- Clones dependabot's PR: https://github.com/CarbonixUAV/cxpilot-config/pull/23
- Updates from deprecated app-id to client-id for the ci bot
- Skips CI steps for future dependabot PRs that require secrets

For good security reasons, dependabot PR runs aren't allowed access to secrets. If you want to test CI for a dependabot PR before merging, simply clone the PR and open it yourself. I think most really simple bumps in the future are fine to yolo merge without CI. Can always test with a manual dispatch too.